### PR TITLE
Configure the Frontend task to use ssl through the docker compose dev file

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -40,7 +40,11 @@
         {
             "label": "Container - Frontend",
             "type": "shell",
-            "command": "docker run -p 3000:3000 cccs/assemblyline-ui-frontend",
+            "command": "docker-compose up al_frontend",
+            "options": {
+                "cwd": "${workspaceFolder}/assemblyline-base/dev/core",
+            },
+            "problemMatcher": [],
             "runOptions": {
                 "instanceLimit": 1
             }


### PR DESCRIPTION
This will have a side effect of using the version of the container that is declared in the docker compose file, which is currently `stable` instead of `latest`.