### PR TITLE
add-ppa-repo proxy env preservation

### DIFF
--- a/setup_vscode.sh
+++ b/setup_vscode.sh
@@ -106,7 +106,7 @@ git clone git@github.com:CybercentreCanada/assemblyline-v4-service.git || git cl
 # Setup dependencies
 sudo DEBIAN_FRONTEND=noninteractive apt-get update -y
 sudo DEBIAN_FRONTEND=noninteractive apt install -y software-properties-common
-sudo DEBIAN_FRONTEND=noninteractive add-apt-repository -y ppa:deadsnakes/ppa
+sudo -E DEBIAN_FRONTEND=noninteractive add-apt-repository -y ppa:deadsnakes/ppa
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y python3-venv python3.11 python3.11-dev python3.11-venv libffi7
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y libfuzzy2 libmagic1 libldap-common libsasl2-2 build-essential libffi-dev libfuzzy-dev libldap2-dev libsasl2-dev libssl-dev
 


### PR DESCRIPTION
added `-E` for ppa install in order to preserve environment variables with proxy config for `add-ppa-repository`. This change makes it so that in environments where a strict network proxy is present the `add-ppa-repository` command will use the proxy server defined in the user's environment variables. This is needed as the `add-ppa-repository` command does not use the default apt proxy configuration, and instead relies on the user's environment variables. These variables, however, get lost without the usage of `sudo -E`.

If `sudo -E` is not used, the following timeout takes place:
> the "!! Adding ppa repo without sudo -E" is added by myself during debugging and is not part of this change.

```
fatal: destination path 'assemblyline-v4-service' already exists and is not an empty directory.
assemblyline-v4-service repo already exists
Hit:1 http://nl.archive.ubuntu.com/ubuntu jammy InRelease
Hit:2 http://nl.archive.ubuntu.com/ubuntu jammy-updates InRelease                                                                                           
Hit:3 http://security.ubuntu.com/ubuntu jammy-security InRelease                                                                                            
Hit:4 https://download.docker.com/linux/ubuntu focal InRelease                                                                                              
Hit:5 http://nl.archive.ubuntu.com/ubuntu jammy-backports InRelease                                  
Hit:6 https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy InRelease
Reading package lists... Done
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
software-properties-common is already the newest version (0.99.22.9).
0 upgraded, 0 newly installed, 0 to remove and 5 not upgraded.
!! Adding ppa repo without sudo -E
Traceback (most recent call last):
  File "/usr/bin/add-apt-repository", line 364, in <module>
    sys.exit(0 if addaptrepo.main() else 1)
  File "/usr/bin/add-apt-repository", line 347, in main
    shortcut = handler(source, **shortcut_params)
  File "/usr/lib/python3/dist-packages/softwareproperties/shortcuts.py", line 40, in shortcut_handler
    return handler(shortcut, **kwargs)
  File "/usr/lib/python3/dist-packages/softwareproperties/ppa.py", line 82, in __init__
    if self.lpppa.publish_debug_symbols:
  File "/usr/lib/python3/dist-packages/softwareproperties/ppa.py", line 120, in lpppa
    self._lpppa = self.lpteam.getPPAByName(name=self.ppaname)
  File "/usr/lib/python3/dist-packages/softwareproperties/ppa.py", line 107, in lpteam
    self._lpteam = self.lp.people(self.teamname)
  File "/usr/lib/python3/dist-packages/softwareproperties/ppa.py", line 98, in lp
    self._lp = login_func("%s.%s" % (self.__module__, self.__class__.__name__),
  File "/usr/lib/python3/dist-packages/launchpadlib/launchpad.py", line 494, in login_anonymously
    return cls(
  File "/usr/lib/python3/dist-packages/launchpadlib/launchpad.py", line 230, in __init__
    super(Launchpad, self).__init__(
  File "/usr/lib/python3/dist-packages/lazr/restfulclient/resource.py", line 472, in __init__
    self._wadl = self._browser.get_wadl_application(self._root_uri)
  File "/usr/lib/python3/dist-packages/lazr/restfulclient/_browser.py", line 447, in get_wadl_application
    response, content = self._request(url, media_type=wadl_type)
  File "/usr/lib/python3/dist-packages/lazr/restfulclient/_browser.py", line 389, in _request
    response, content = self._request_and_retry(
  File "/usr/lib/python3/dist-packages/lazr/restfulclient/_browser.py", line 359, in _request_and_retry
    response, content = self._connection.request(
  File "/usr/lib/python3/dist-packages/httplib2/__init__.py", line 1725, in request
    (response, content) = self._request(
  File "/usr/lib/python3/dist-packages/launchpadlib/launchpad.py", line 144, in _request
    response, content = super(LaunchpadOAuthAwareHttp, self)._request(
  File "/usr/lib/python3/dist-packages/lazr/restfulclient/_browser.py", line 184, in _request
    return super(RestfulHttp, self)._request(
  File "/usr/lib/python3/dist-packages/httplib2/__init__.py", line 1441, in _request
    (response, content) = self._conn_request(conn, request_uri, method, body, headers)
  File "/usr/lib/python3/dist-packages/httplib2/__init__.py", line 1363, in _conn_request
    conn.connect()
  File "/usr/lib/python3/dist-packages/httplib2/__init__.py", line 1153, in connect
    sock.connect((self.host, self.port))
TimeoutError: [Errno 110] Connection timed out
```